### PR TITLE
Feat 0028 re run for failed cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         if: always()
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT=Complete Execution for $ENVIRONMENT on $BROWSER
+          export SUBJECT=Complete Execution for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}
@@ -95,7 +95,7 @@ jobs:
         if: steps.Run_Test.outcome == 'failure'
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT=Re-run Failed Test Cases for $ENVIRONMENT on $BROWSER
+          export SUBJECT=Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         run: mvn clean install -DskipTests
 
       - name: Run tests
+        id: Run_Test
         run: |
           export BROWSER=${{ github.event.inputs.Browser }}
           export HEADLESS=true
@@ -78,6 +79,23 @@ jobs:
         if: always()
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
+          export SUBJECT=Complete Execution for $ENVIRONMENT on $BROWSER
+          mvn exec:java
+        env:
+          EMAIL_USER: ${{ secrets.SENDER_EMAIL }}
+          EMAIL_PASSWORD: ${{ secrets.SENDER_APP_PASSWORD }}
+
+      - name: Re-run failed tests
+        id: Re_Run_Test
+        if: steps.Run_Test.outcome == 'failure'
+        run: |
+          mvn test -DsuiteXmlFile=target/surefire-reports/testng-failed.xml
+
+      - name: Re-send result via email
+        if: steps.Run_Test.outcome == 'failure'
+        run: |
+          export EMAIL=${{ github.event.inputs.Email }}
+          export SUBJECT=Re-run Failed Test Cases for $ENVIRONMENT on $BROWSER
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         if: always()
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT="Complete Execution for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}"
+          export SUBJECT="Complete Execution for ${{ github.event.inputs.Environment }} Environment on ${{ github.event.inputs.Browser }} Browser"
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}
@@ -98,7 +98,7 @@ jobs:
         if: ${{ failure() && steps.Run_Test.outcome == 'failure' }}
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT="Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}"
+          export SUBJECT="Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} Environment on ${{ github.event.inputs.Browser }} Browser"
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,17 +52,17 @@ jobs:
         if: ${{ github.event.inputs.Browser == 'edge' }}
         uses: browser-actions/setup-edge@v1.1.1
 
-      - name: Setup Chrome WebDriver
-        if: ${{ github.event.inputs.Browser == 'chrome' }}
-        uses: browser-actions/setup-chrome@v1.7.2
-
-      - name: Setup Firefox WebDriver
-        if: ${{ github.event.inputs.Browser == 'firefox' }}
-        uses: browser-actions/setup-firefox@v1.5.2
-
-      - name: Setup Edge WebDriver
-        if: ${{ github.event.inputs.Browser == 'edge' }}
-        uses: browser-actions/setup-edge@v1.1.1
+#      - name: Setup Chrome WebDriver
+#        if: ${{ github.event.inputs.Browser == 'chrome' }}
+#        uses: browser-actions/setup-chrome@v1.7.2
+#
+#      - name: Setup Firefox WebDriver
+#        if: ${{ github.event.inputs.Browser == 'firefox' }}
+#        uses: browser-actions/setup-firefox@v1.5.2
+#
+#      - name: Setup Edge WebDriver
+#        if: ${{ github.event.inputs.Browser == 'edge' }}
+#        uses: browser-actions/setup-edge@v1.1.1
 
       - name: Install dependencies without running tests
         run: mvn clean install -DskipTests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: manual workflow
+name: Manual workflow for automation testcases
 
 on:
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         if: always()
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT=Complete Execution for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}
+          export SUBJECT="Complete Execution for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}"
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}
@@ -87,15 +87,15 @@ jobs:
 
       - name: Re-run failed tests
         id: Re_Run_Test
-        if: steps.Run_Test.outcome == 'failure'
+        if: ${{ steps.Run_Test.outcome == 'failure' }}
         run: |
           mvn test -DsuiteXmlFile=target/surefire-reports/testng-failed.xml
 
       - name: Re-send result via email
-        if: steps.Run_Test.outcome == 'failure'
+        if: ${{ steps.Run_Test.outcome == 'failure' }}
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
-          export SUBJECT=Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}
+          export SUBJECT="Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}"
           mvn exec:java
         env:
           EMAIL_USER: ${{ secrets.SENDER_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,12 @@ jobs:
 
       - name: Re-run failed tests
         id: Re_Run_Test
-        if: ${{ steps.Run_Test.outcome == 'failure' }}
+        if: ${{ failure() && steps.Run_Test.outcome == 'failure' }}
         run: |
           mvn test -DsuiteXmlFile=target/surefire-reports/testng-failed.xml
 
       - name: Re-send result via email
-        if: ${{ steps.Run_Test.outcome == 'failure' }}
+        if: ${{ failure() && steps.Run_Test.outcome == 'failure' }}
         run: |
           export EMAIL=${{ github.event.inputs.Email }}
           export SUBJECT="Re-run Failed Test Cases for ${{ github.event.inputs.Environment }} on ${{ github.event.inputs.Browser }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,18 +52,6 @@ jobs:
         if: ${{ github.event.inputs.Browser == 'edge' }}
         uses: browser-actions/setup-edge@v1.1.1
 
-#      - name: Setup Chrome WebDriver
-#        if: ${{ github.event.inputs.Browser == 'chrome' }}
-#        uses: browser-actions/setup-chrome@v1.7.2
-#
-#      - name: Setup Firefox WebDriver
-#        if: ${{ github.event.inputs.Browser == 'firefox' }}
-#        uses: browser-actions/setup-firefox@v1.5.2
-#
-#      - name: Setup Edge WebDriver
-#        if: ${{ github.event.inputs.Browser == 'edge' }}
-#        uses: browser-actions/setup-edge@v1.1.1
-
       - name: Install dependencies without running tests
         run: mvn clean install -DskipTests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
         id: Re_Run_Test
         if: ${{ failure() && steps.Run_Test.outcome == 'failure' }}
         run: |
+          export BROWSER=${{ github.event.inputs.Browser }}
+          export HEADLESS=true
+          export ENV=${{ github.event.inputs.Environment }}
           mvn test -DsuiteXmlFile=target/surefire-reports/testng-failed.xml
 
       - name: Re-send result via email

--- a/src/main/java/com/selenium/testng/elite/utils/ResultMaker.java
+++ b/src/main/java/com/selenium/testng/elite/utils/ResultMaker.java
@@ -1,0 +1,39 @@
+package com.selenium.testng.elite.utils;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+public class ResultMaker {
+
+  public static void writeFailedTestCasesToFile(List<String> failedTests) {
+    try (BufferedWriter writer =
+        new BufferedWriter(new FileWriter(PathHelper.getListOfFailedTestCasesFile(), false))) {
+      writer.write("List of test cases which are failed:");
+      writer.newLine();
+
+      // Loop through the list and write each test case with a number
+      int index = 1;
+      for (String testCase : failedTests) {
+        writer.write(index + ") " + testCase);
+        writer.newLine();
+        index++;
+      }
+    } catch (IOException e) {
+      e.printStackTrace(); // Handle any IO exceptions
+    }
+
+    System.out.println("Failed test cases written to file: " + PathHelper.getListOfFailedTestCasesFile());
+  }
+
+  public static void writeGoodMessageInTestCaseFailedFile() {
+    try (BufferedWriter writer =
+        new BufferedWriter(new FileWriter(PathHelper.getListOfFailedTestCasesFile(), false))) {
+      writer.write("All Test cases are passed!! Congratulations!");
+    } catch (IOException e) {
+      e.printStackTrace(); // Handle any IO exceptions
+    }
+    System.out.println("No failed test cases found");
+  }
+}

--- a/src/main/java/emailHelper/sendEmailWithAttachment.java
+++ b/src/main/java/emailHelper/sendEmailWithAttachment.java
@@ -7,6 +7,7 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
+import org.apache.commons.io.FileUtils;
 
 import java.io.*;
 import java.util.Properties;
@@ -126,6 +127,10 @@ public class sendEmailWithAttachment {
         lineCount++;
       }
       reader.close();
+
+      // Now delete the file so we don't get repetitive content
+      FileUtils.forceDelete(new File(filePath));
+
     } catch (Exception e) {
       e.printStackTrace();
       content.append("Congratulations! No failed test cases found");

--- a/src/main/java/emailHelper/sendEmailWithAttachment.java
+++ b/src/main/java/emailHelper/sendEmailWithAttachment.java
@@ -7,8 +7,6 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
-import org.apache.commons.io.FileUtils;
-
 import java.io.*;
 import java.util.Properties;
 
@@ -127,10 +125,6 @@ public class sendEmailWithAttachment {
         lineCount++;
       }
       reader.close();
-
-      // Now delete the file so we don't get repetitive content
-      FileUtils.forceDelete(new File(filePath));
-
     } catch (Exception e) {
       e.printStackTrace();
       content.append("Congratulations! No failed test cases found");

--- a/src/main/java/emailHelper/sendEmailWithAttachment.java
+++ b/src/main/java/emailHelper/sendEmailWithAttachment.java
@@ -22,10 +22,11 @@ public class sendEmailWithAttachment {
     String failedTestCasesFilePath = PathHelper.getListOfFailedTestCasesFile();
 
     // Read the content of the text file
-    StringBuilder content = readTextFile(txtFilePath);
+    String subject = dotenv.get("SUBJECT");
+    StringBuilder content = (!subject.contains("Re-run")) ? null : readTextFile(txtFilePath);
     StringBuilder failedTextCasesList = readFailedTextCaseListFile(failedTestCasesFilePath);
 
-    String subject = dotenv.get("SUBJECT");
+    // Build the email body
     String body =
         """
           Hello Team,
@@ -110,20 +111,25 @@ public class sendEmailWithAttachment {
     return content;
   }
 
-  private static StringBuilder readTextFile(String filePath) throws IOException {
+  private static StringBuilder readTextFile(String filePath) {
     StringBuilder content = new StringBuilder();
-    BufferedReader reader = new BufferedReader(new FileReader(filePath));
-    String line;
-    int lineCount = 0;
-    while ((line = reader.readLine()) != null && lineCount < 4) {
-      // Remove the unwanted string from the 4th line
-      if (line.contains("<<< FAILURE! -- in TestSuite")) {
-        line = line.replace("<<< FAILURE! -- in TestSuite", "");
+    try {
+      BufferedReader reader = new BufferedReader(new FileReader(filePath));
+      String line;
+      int lineCount = 0;
+      while ((line = reader.readLine()) != null && lineCount < 4) {
+        // Remove the unwanted string from the 4th line
+        if (line.contains("<<< FAILURE! -- in TestSuite")) {
+          line = line.replace("<<< FAILURE! -- in TestSuite", "");
+        }
+        content.append(line).append("\n"); // Append the line to the content
+        lineCount++;
       }
-      content.append(line).append("\n"); // Append the line to the content
-      lineCount++;
+      reader.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      content.append("Congratulations! No failed test cases found");
     }
-    reader.close();
     return content;
   }
 }

--- a/src/main/java/emailHelper/sendEmailWithAttachment.java
+++ b/src/main/java/emailHelper/sendEmailWithAttachment.java
@@ -24,7 +24,7 @@ public class sendEmailWithAttachment {
 
     // Read the content of the text file
     String subject = dotenv.get("SUBJECT");
-    StringBuilder content = (!subject.contains("Re-run")) ? null : readTextFile(txtFilePath);
+    StringBuilder content = readTextFile(txtFilePath);
     StringBuilder failedTextCasesList = readFailedTextCaseListFile(failedTestCasesFilePath);
 
     // Build the email body

--- a/src/main/java/emailHelper/sendEmailWithAttachment.java
+++ b/src/main/java/emailHelper/sendEmailWithAttachment.java
@@ -25,7 +25,7 @@ public class sendEmailWithAttachment {
     StringBuilder content = readTextFile(txtFilePath);
     StringBuilder failedTextCasesList = readFailedTextCaseListFile(failedTestCasesFilePath);
 
-    String subject = "Automation Test Report Results";
+    String subject = dotenv.get("SUBJECT");
     String body =
         """
           Hello Team,

--- a/src/test/java/com/selenium/testng/elite/BaseTest.java
+++ b/src/test/java/com/selenium/testng/elite/BaseTest.java
@@ -87,7 +87,7 @@ public class BaseTest {
 
   // Method to write the list of failed test cases to a file
   private static void writeFailedTestCasesToFile() {
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(PathHelper.getListOfFailedTestCasesFile(), true))) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(PathHelper.getListOfFailedTestCasesFile(), false))) {
       writer.write("List of test cases which are failed:");
       writer.newLine();
 

--- a/src/test/java/com/selenium/testng/elite/BaseTest.java
+++ b/src/test/java/com/selenium/testng/elite/BaseTest.java
@@ -81,7 +81,4 @@ public class BaseTest {
     System.out.println(
         "Screenshot: file://" + PathHelper.getEncodedPathForScreenShot(screenShotPath));
   }
-
-  // Method to write the list of failed test cases to a file
-
 }

--- a/src/test/java/com/selenium/testng/elite/BaseTest.java
+++ b/src/test/java/com/selenium/testng/elite/BaseTest.java
@@ -3,15 +3,10 @@ package com.selenium.testng.elite;
 import com.aventstack.extentreports.ExtentReports;
 import com.aventstack.extentreports.ExtentTest;
 import com.aventstack.extentreports.MediaEntityBuilder;
-import com.selenium.testng.elite.utils.Constant;
-import com.selenium.testng.elite.utils.ExtentManager;
-import com.selenium.testng.elite.utils.Log;
-import com.selenium.testng.elite.utils.PathHelper;
+import com.selenium.testng.elite.utils.*;
 import com.selenium.utils.DriverFactory;
 import com.selenium.utils.EnvironmentConfig;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +59,8 @@ public class BaseTest {
 
   @AfterSuite
   public void afterSuite() {
-    if (!failedTests.isEmpty()) writeFailedTestCasesToFile();
+    if (!failedTests.isEmpty()) ResultMaker.writeFailedTestCasesToFile(failedTests);
+    else ResultMaker.writeGoodMessageInTestCaseFailedFile();
   }
 
   private void setUpReportAndLogger(ITestResult result) {
@@ -82,26 +78,10 @@ public class BaseTest {
     FileUtils.copyFile(screenshot, new File(screenShotPath));
     extentTest.fail(
         MediaEntityBuilder.createScreenCaptureFromBase64String(screenshotBase64).build());
-    System.out.println("Screenshot: file://" + PathHelper.getEncodedPathForScreenShot(screenShotPath));
+    System.out.println(
+        "Screenshot: file://" + PathHelper.getEncodedPathForScreenShot(screenShotPath));
   }
 
   // Method to write the list of failed test cases to a file
-  private static void writeFailedTestCasesToFile() {
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(PathHelper.getListOfFailedTestCasesFile(), false))) {
-      writer.write("List of test cases which are failed:");
-      writer.newLine();
 
-      // Loop through the list and write each test case with a number
-      int index = 1;
-      for (String testCase : BaseTest.failedTests) {
-        writer.write(index + ") " + testCase);
-        writer.newLine();
-        index++;
-      }
-    } catch (IOException e) {
-      e.printStackTrace(); // Handle any IO exceptions
-    }
-
-    System.out.println("Failed test cases written to file: " + PathHelper.getListOfFailedTestCasesFile());
-  }
 }


### PR DESCRIPTION
I've updated the re-run strategy of the framework and implemented a feature to send an email with the list of failed test cases. Currently, two separate emails are being sent, but moving forward, these will be merged into a single email that consolidates both sets of test case results.