### PR TITLE
feat-0039-After-Suit-Extent-Report-Open-Automatically

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,6 @@ HEADLESS=false
 
 #DEBUG: It could be true or false
 IS_DEBUG=false
+
+#Want_To_Open_Report: It could be true or false
+WANT_TO_OPEN_REPORT=false

--- a/src/test/java/com/selenium/testng/elite/BaseTest.java
+++ b/src/test/java/com/selenium/testng/elite/BaseTest.java
@@ -7,6 +7,7 @@ import com.selenium.testng.elite.utils.*;
 import com.selenium.utils.DriverFactory;
 import com.selenium.utils.EnvironmentConfig;
 import elementHelper.web.FileHelper;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,6 +67,7 @@ public class BaseTest {
   public void afterSuite() {
     FileHelper.deleteAllFiles();
     ResultMaker.CreateFileForResult(failedTests, passedTests);
+    openExtentReport(environmentConfig.isWantToOpenReports());
   }
 
   private void setUpReportAndLogger(ITestResult result) {
@@ -85,5 +87,16 @@ public class BaseTest {
         MediaEntityBuilder.createScreenCaptureFromBase64String(screenshotBase64).build());
     System.out.println(
         "Screenshot: file://" + PathHelper.getEncodedPathForScreenShot(screenShotPath));
+  }
+
+  private void openExtentReport(boolean wantToOpenReports) {
+    if (wantToOpenReports) {
+      try {
+        Desktop desktop = Desktop.getDesktop();
+        desktop.browse(new File(PathHelper.getPathForReport()).toURI());
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
   }
 }

--- a/src/test/java/com/selenium/utils/EnvironmentConfig.java
+++ b/src/test/java/com/selenium/utils/EnvironmentConfig.java
@@ -16,6 +16,7 @@ public class EnvironmentConfig {
   private final PlatformName platform;
   private final boolean headless;
   private final EnvironmentType environment;
+  private final boolean wantToOpenReports;
 
   public EnvironmentConfig() {
 
@@ -36,5 +37,6 @@ public class EnvironmentConfig {
     Constant.loadConstants(environmentBasedConfig);
 
     headless = Boolean.parseBoolean(globalDotenv.get("HEADLESS"));
+    wantToOpenReports = Boolean.parseBoolean(globalDotenv.get("WANT_TO_OPEN_REPORT"));
   }
 }


### PR DESCRIPTION
Commit 0044 - I created an environment variable 'Want_To_Open_Reports' in the .env file. If you pass true, after the suit runs, it will open the report in the default browser.